### PR TITLE
Simple support for seeding / tailing multiple channels simultaneously.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ if (!argv.channel && !argv.feed || argv.help) {
 
 if (argv.channel) argv.channel = argv.channel.replace(/^#/, '')
 
-var lev = level('hyperirc.db.' + dbKey)
+var lev = level('hyperirc.db')
 var dbKey = argv.channel ? argv.channel : argv.feed
 var db = sub(lev, dbKey)
 var core = hypercore(db)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var argv = minimist(process.argv.slice(2), {
     channel: 'c',
     feed: 'f',
     server: 's',
-    name: 'n',
+    name: 'n'
   },
   default: {
     server: 'irc.freenode.net',
@@ -38,7 +38,8 @@ if (!argv.channel && !argv.feed || argv.help) {
 
 if (argv.channel) argv.channel = argv.channel.replace(/^#/, '')
 
-var db = level('hyperirc.db')
+var dbKey = argv.channel ? argv.channel : argv.feed
+var db = level('hyperirc.db.' + dbKey)
 var core = hypercore(db)
 
 db.get('!hyperirc!!channels!' + argv.channel, {valueEncoding: 'binary'}, function (_, key) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 var irc = require('irc')
-var level = require('level')
+var sub = require('subleveldown')
+var level = require('level-party')
 var hypercore = require('hypercore')
 var swarm = require('discovery-swarm')
 var defaults = require('datland-swarm-defaults')
@@ -38,8 +39,9 @@ if (!argv.channel && !argv.feed || argv.help) {
 
 if (argv.channel) argv.channel = argv.channel.replace(/^#/, '')
 
+var lev = level('hyperirc.db.' + dbKey)
 var dbKey = argv.channel ? argv.channel : argv.feed
-var db = level('hyperirc.db.' + dbKey)
+var db = sub(lev, dbKey)
 var core = hypercore(db)
 
 db.get('!hyperirc!!channels!' + argv.channel, {valueEncoding: 'binary'}, function (_, key) {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "electron-webrtc": "^0.2.5",
     "hypercore": "^4.2.5",
     "irc": "^0.5.0",
-    "level": "^1.4.0",
-    "minimist": "^1.2.0"
+    "level-party": "^3.0.4",
+    "minimist": "^1.2.0",
+    "subleveldown": "^2.1.0"
   },
   "devDependencies": {
     "standard": "^7.1.2"


### PR DESCRIPTION
I implemented this in the stupid way, not using multileveldown. 

A unique name for the level database is generated, using the name of the channel (if given), else the key of the feed.

I was wondering: what does multileveldown provide that we don't get by just using different names for the different channel dbs?
