### PR TITLE
Default db location to `~/.hyperirc.db`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ hyperirc --tail=the-key-printed-out-above
 
 Thats it! Every peer tailing (and the peer mirroring) will join the p2p network and help eachother host the irc logs.
 
+By default, hyperirc will save its database under `~/.hyperirc.db`. You may choose your own location.
+
+```sh
+hyperirc --mirror=an-irc-channel --database=/path/to/db
+```
+
 For more options run `hyperirc --help`.
 
 ## Browser support

--- a/index.js
+++ b/index.js
@@ -6,12 +6,15 @@ var hypercore = require('hypercore')
 var swarm = require('discovery-swarm')
 var defaults = require('datland-swarm-defaults')
 var minimist = require('minimist')
+var home = require('os-homedir')
+var path = require('path')
 
 var argv = minimist(process.argv.slice(2), {
   alias: {
     mirror: 'channel',
     tail: 'feed',
     channel: 'c',
+    database: 'd',
     feed: 'f',
     server: 's',
     name: 'n'
@@ -28,6 +31,7 @@ if (!argv.channel && !argv.feed || argv.help) {
   console.error('  --mirror=[channel-name]  IRC channel to mirror')
   console.error('  --server=[irc-server]    Optional IRC server. Defaults to freenode')
   console.error('  --tail=[feed-key]        A mirrored channel to tail')
+  console.error('  --database=[db-path]     Path for database. Defaults to ~/.hyperirc.db')
   console.error('  --webrtc                 Share over webrtc as well.')
   console.error('  --all                    Print the entire channel log.')
   console.error()
@@ -38,7 +42,7 @@ if (!argv.channel && !argv.feed || argv.help) {
 
 if (argv.channel) argv.channel = argv.channel.replace(/^#/, '')
 
-var db = level('hyperirc.db')
+var db = level(argv.database || path.join(home(), '.hyperirc.db'))
 var core = hypercore(db)
 
 db.get('!hyperirc!!channels!' + argv.channel, {valueEncoding: 'binary'}, function (_, key) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "hypercore": "^4.2.5",
     "irc": "^0.5.0",
     "level-party": "^3.0.4",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "os-homedir": "^1.0.1"
   },
   "devDependencies": {
     "standard": "^7.1.2"


### PR DESCRIPTION
Regarding https://github.com/mafintosh/hyperirc/issues/3#issuecomment-225338194

Maybe deprecate older versions or something with a message telling them to move their db to the new location?
