### PR TITLE
Update mirrored IRC channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ To view the logs in the browser visit the static website hosted here, https://gi
 
 ## Mirrored IRC channels
 
-* #dat on freenode, `hyperirc --tail=4e397d94d0f5df0e2268b2b7b23948b6dddfca66f91c2d452f404202e6d0f626`
-* #datland on freenode, `hyperirc --tail=c171af3ab6d6936f8b4d3a9abb19f2f2adccf1c27a6c2bf17e05950f30ac698f`
+* #dat on freenode, `hyperirc --tail=227d9212ee85c0f14416885c5390f2d270ba372252e781bf45a6b7056bb0a1b5`
+* #sciencefair on freenode, `hyperirc --tail=d5ec4f72d2dfde000510b1d84912242a2c10400bbd9721311a548a1e3a7913b5`
+* #beakerbrowser on freenode, `hyperirc --tail=18bab41fd4cfd47425226bebf6030ef270091481b39a1959768c2ccc90db02a3`
 * #cphftw on freenode, `hyperirc --tail=f93d568521e82722e4473ac0563aa8d4a2e2becb5c6dd2e1276532c5f4e521a0`
 * #stackvm on freenode, `hyperirc --tail=9d25a90d0422904b876d226116903809a374dc4156b0b349f55ccf9e19ecfbd4`
 


### PR DESCRIPTION
Mirroring `#dat`, `#sciencefair`, `#beakerbrowser`, `#codeforscience` on google2. 

cphftw & stackvm may still be outdated.