### PR TITLE
Use date constructor when printing data timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ feed.ready(function () {
     function tail () {
       var stream = feed.createReadStream({live: true, start: argv.all ? 1 : Math.max(feed.length - 10, 1)})
         .on('data', function (data) {
-          console.log(`${Date(data.timestamp).toLocaleString()} ${data.from} > ${data.message}`)
+          console.log(`${new Date(data.timestamp).toLocaleString()} ${data.from} > ${data.message}`)
         })
 
       return stream


### PR DESCRIPTION
When running a --tail:xxx --all I noticed that the timestamps were printing the current system time. I verified the stored values were correct so it was only the printed log messages that were affected. 

Adding the 'new' keyword resolves this issue.

From MDN:
```JavaScript Date objects can only be instantiated by calling JavaScript Date as a constructor: calling it as a regular function (i.e. without the new operator) will return a string rather than a Date object; unlike other JavaScript object types, JavaScript Date objects have no literal syntax.```